### PR TITLE
Added support for resetting selected fields

### DIFF
--- a/src/main/java/de/otto/flummi/request/SearchRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/SearchRequestBuilder.java
@@ -108,6 +108,11 @@ public class SearchRequestBuilder implements RequestBuilder<SearchResponse> {
         return this;
     }
 
+    public SearchRequestBuilder resetFields() {
+        fields = new JsonArray();
+        return this;
+    }
+
     public SearchRequestBuilder setTimeoutMillis(Integer timeoutMillis) {
         this.timeoutMillis = timeoutMillis;
         return this;

--- a/src/test/java/de/otto/flummi/SearchRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/SearchRequestBuilderTest.java
@@ -87,6 +87,23 @@ public class SearchRequestBuilderTest {
     }
 
     @Test
+    public void shouldCreateQueryWithoutAnyFieldsSelectedAfterResetFields() throws Exception {
+        // given
+        AsyncHttpClient.BoundRequestBuilder boundRequestBuilderMock = mock(AsyncHttpClient.BoundRequestBuilder.class);
+        when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.setBodyEncoding(anyString())).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
+
+        // when
+        SearchResponse response = searchRequestBuilder.setQuery(createSampleQuery()).resetFields().execute();
+
+        //then
+        verify(boundRequestBuilderMock).setBody("{\"query\":{\"term\":{\"someField\":\"someValue\"}},\"fields\":[]}");
+        verify(httpClient).preparePost("/some-index/_search");
+    }
+
+    @Test
     public void shouldParseSearchResponseWithFullDocuments() throws Exception {
         // given
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilderMock = mock(AsyncHttpClient.BoundRequestBuilder.class);


### PR DESCRIPTION
This allows to issue a query without any fields selected, useful
if you only need hit metadata like hit ID and don't want to transfer
entire document data over the network