### PR TITLE
Add _analyze API handling.

### DIFF
--- a/src/main/java/de/otto/flummi/Flummi.java
+++ b/src/main/java/de/otto/flummi/Flummi.java
@@ -74,6 +74,10 @@ public class Flummi {
         return new MultiGetRequestBuilder(httpClient, indices);
     }
 
+    public AnalyzeRequestBuilder prepareAnalyze(String text) {
+        return new AnalyzeRequestBuilder(httpClient, text);
+    }
+
     public SearchScrollRequestBuilder prepareScroll() {
         return new SearchScrollRequestBuilder(httpClient);
     }

--- a/src/main/java/de/otto/flummi/request/AnalyzeRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/AnalyzeRequestBuilder.java
@@ -1,0 +1,162 @@
+package de.otto.flummi.request;
+
+import com.google.gson.*;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.Response;
+import de.otto.flummi.RequestBuilderUtil;
+import de.otto.flummi.response.AnalyzeResponse;
+import de.otto.flummi.response.Token;
+import de.otto.flummi.util.HttpClientWrapper;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class AnalyzeRequestBuilder implements RequestBuilder<AnalyzeResponse> {
+    private HttpClientWrapper httpClient;
+    private final Gson gson;
+    private String indexName;
+    private final String text;
+    private String tokenizer;
+    private String analyzer;
+    private String field;
+    private JsonArray filters;
+    private JsonArray characterFilters;
+
+    public static final Logger LOG = getLogger(AnalyzeRequestBuilder.class);
+
+    public AnalyzeRequestBuilder(HttpClientWrapper httpClient, String text) {
+        this.httpClient = httpClient;
+        this.text = text;
+        this.gson = new Gson();
+    }
+
+    @Override
+    public AnalyzeResponse execute() {
+        JsonObject body = new JsonObject();
+        try {
+            String url = buildUrl();
+
+            if (text != null) {
+                body.add("text", new JsonPrimitive(text));
+            }
+
+            if (analyzer != null) {
+                body.add("analyzer", new JsonPrimitive(analyzer));
+            }
+
+            if (tokenizer != null) {
+                body.add("tokenizer", new JsonPrimitive(tokenizer));
+            }
+
+            if (field != null) {
+                body.add("field", new JsonPrimitive(field));
+            }
+
+            if (filters != null) {
+                body.add("filter", filters);
+            }
+
+            if (characterFilters != null) {
+                body.add("char_filter", characterFilters);
+            }
+
+            Response response = httpClient
+                    .prepareGet(url)
+                    .setBodyEncoding("UTF-8")
+                    .setBody(gson.toJson(body))
+                    .execute()
+                    .get();
+
+            if (response.getStatusCode() != 200) {
+                throw toHttpServerErrorException(response);
+            }
+
+            JsonObject jsonResponse = gson.fromJson(response.getResponseBody(), JsonObject.class);
+            AnalyzeResponse.Builder analyzeResponse = parseResponse(jsonResponse);
+
+            return analyzeResponse.build();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildUrl() {
+        StringBuilder urlBuilder = new StringBuilder();
+        if (indexName != null) {
+            urlBuilder.append("/").append(indexName);
+        }
+        urlBuilder.append("/").append("_analyze");
+        return urlBuilder.toString();
+    }
+
+    public AnalyzeRequestBuilder setTokenizer(String tokenizer) {
+        this.tokenizer = tokenizer;
+        return this;
+    }
+
+    public AnalyzeRequestBuilder setAnalyzer(String analyzer) {
+        this.analyzer = analyzer;
+        return this;
+    }
+
+    public AnalyzeRequestBuilder setIndexName(String indexName) {
+        this.indexName = indexName;
+        return this;
+    }
+
+    public AnalyzeRequestBuilder appendFilter(String filter) {
+        if (filters == null) {
+            filters = new JsonArray();
+        }
+
+        filters.add(new JsonPrimitive(filter));
+        return this;
+    }
+
+    public AnalyzeRequestBuilder appendCharacterFilter(String characterFilter) {
+        if (characterFilters == null) {
+            characterFilters = new JsonArray();
+        }
+
+        characterFilters.add(new JsonPrimitive(characterFilter));
+        return this;
+    }
+
+    public AnalyzeRequestBuilder setField(String field) {
+        this.field = field;
+        return this;
+    }
+
+    public static AnalyzeResponse.Builder parseResponse(JsonObject jsonObject) {
+        AnalyzeResponse.Builder analyzeResponse = AnalyzeResponse.builder();
+        JsonArray tokensArray = jsonObject.get("tokens").getAsJsonArray();
+
+        List<Token> tokens = new ArrayList<>();
+        for (JsonElement element : tokensArray) {
+            JsonObject asJsonObject = element.getAsJsonObject();
+            String token = asJsonObject.get("token").getAsString();
+            String type = asJsonObject.get("type").getAsString();
+            Integer position = asJsonObject.get("position").getAsInt();
+            Integer startOffset = asJsonObject.get("start_offset").getAsInt();
+            Integer endOffset = asJsonObject.get("end_offset").getAsInt();
+            Token t = new Token(token, type, position, startOffset, endOffset);
+            tokens.add(t);
+        }
+
+        analyzeResponse.setHits(tokens);
+
+        return analyzeResponse;
+    }
+}

--- a/src/main/java/de/otto/flummi/response/AnalyzeResponse.java
+++ b/src/main/java/de/otto/flummi/response/AnalyzeResponse.java
@@ -1,0 +1,40 @@
+package de.otto.flummi.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+public class AnalyzeResponse  {
+    private final List<Token> tokens;
+
+    public AnalyzeResponse(List<Token> tokens) {
+        this.tokens = tokens;
+    }
+
+    public List<Token> getTokens(){
+        return tokens;
+    };
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static AnalyzeResponse emptyResponse() {
+        return new AnalyzeResponse(emptyList());
+    }
+
+    public static final class Builder {
+        private List<Token> tokens = new ArrayList<>();
+
+        public Builder setHits(List<Token> tokens) {
+            this.tokens = tokens;
+            return this;
+        }
+
+        public AnalyzeResponse build() {
+            return new AnalyzeResponse(tokens);
+        }
+    }
+}
+

--- a/src/main/java/de/otto/flummi/response/Token.java
+++ b/src/main/java/de/otto/flummi/response/Token.java
@@ -1,0 +1,74 @@
+package de.otto.flummi.response;
+
+public class Token {
+    private final String token;
+    private final String type;
+    private final Integer position;
+    private final Integer startOffset;
+    private final Integer endOffset;
+
+    public Token(String token, String type, Integer position, Integer startOffset, Integer endOffset) {
+        this.token = token;
+        this.type = type;
+        this.position = position;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public Integer getEndOffset() {
+        return endOffset;
+    }
+
+    public Integer getStartOffset() {
+        return startOffset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Token token1 = (Token) o;
+
+        if (token != null ? !token.equals(token1.token) : token1.token != null) return false;
+        if (type != null ? !type.equals(token1.type) : token1.type != null) return false;
+        if (position != null ? !position.equals(token1.position) : token1.position != null) return false;
+        if (endOffset != null ? !endOffset.equals(token1.endOffset) : token1.endOffset != null) return false;
+        return startOffset != null ? startOffset.equals(token1.startOffset) : token1.startOffset == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = token != null ? token.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (position != null ? position.hashCode() : 0);
+        result = 31 * result + (endOffset != null ? endOffset.hashCode() : 0);
+        result = 31 * result + (startOffset != null ? startOffset.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Token{");
+        sb.append("token='").append(token).append('\'');
+        sb.append(", type='").append(type).append('\'');
+        sb.append(", position=").append(position);
+        sb.append(", startOffset=").append(startOffset);
+        sb.append(", endOffset=").append(endOffset);
+        sb.append('}');
+        return sb.toString();
+    }
+}
+

--- a/src/test/java/de/otto/flummi/FlummiTest.java
+++ b/src/test/java/de/otto/flummi/FlummiTest.java
@@ -174,6 +174,27 @@ public class FlummiTest {
     }
 
     @Test
+    public void shouldPrepareAnalyze() throws ExecutionException, InterruptedException, IOException {
+        final AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
+        when(asyncHttpClient.prepareGet(anyString())).thenReturn(boundRequestBuilder);
+        final ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        when(boundRequestBuilder.setBodyEncoding(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        final Response response = mock(Response.class);
+        when(response.getStatusCode()).thenReturn(200);
+        when(response.getResponseBody()).thenReturn("{ \"tokens\": [] }");
+        when(listenableFuture.get()).thenReturn(response);
+        final AnalyzeRequestBuilder analyzeRequestBuilder = client.prepareAnalyze("hello world");
+
+        //When
+        analyzeRequestBuilder.execute();
+
+        //Then
+        verify(asyncHttpClient).prepareGet("http://someHost:9200/_analyze");
+    }
+
+    @Test
     public void shouldPrepareIndex() throws ExecutionException, InterruptedException, IOException {
         //Given
         final AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);

--- a/src/test/java/de/otto/flummi/request/AnalyzeRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/AnalyzeRequestBuilderTest.java
@@ -1,0 +1,226 @@
+package de.otto.flummi.request;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.ning.http.client.AsyncHttpClient;
+import de.otto.flummi.CompletedFuture;
+import de.otto.flummi.MockResponse;
+import de.otto.flummi.response.AnalyzeResponse;
+import de.otto.flummi.response.HttpServerErrorException;
+import de.otto.flummi.response.Token;
+import de.otto.flummi.util.HttpClientWrapper;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+import static de.otto.flummi.request.GsonHelper.object;
+import static de.otto.flummi.request.GsonHelper.array;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class AnalyzeRequestBuilderTest {
+    @Mock
+    HttpClientWrapper httpClient;
+
+    @Mock
+    AsyncHttpClient.BoundRequestBuilder boundRequestBuilder;
+
+    AnalyzeRequestBuilder helloWorldAnalyzeRequestBuilder;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        initMocks(this);
+        when(httpClient.prepareGet(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBodyEncoding(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(
+                new CompletedFuture<>(new MockResponse(200, "ok", helloWorldResponse.toString()))
+        );
+        helloWorldAnalyzeRequestBuilder = new AnalyzeRequestBuilder(httpClient, "Hello World");
+    }
+
+    private JsonObject helloWorldResponse = object(
+            "tokens", array(
+                    createTokenJsonObject("hello", "<ALPHANUM>", 0, 0, 5),
+                    createTokenJsonObject("world", "<ALPHANUM>", 1, 6, 11)
+            )
+    );
+
+
+    @Test
+    public void shouldCorrectlyParseResponse() throws Exception {
+        when(boundRequestBuilder.execute()).thenReturn(
+                new CompletedFuture<>(new MockResponse(200, "ok", helloWorldResponse.toString()))
+        );
+
+        // when
+        AnalyzeResponse analyzerResponse = helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        final ArrayList<Token> expectedTokens = new ArrayList<>();
+        expectedTokens.add(new Token("hello", "<ALPHANUM>", 0, 0, 5));
+        expectedTokens.add(new Token("world", "<ALPHANUM>", 1, 6, 11));
+
+        assertThat(analyzerResponse.getTokens(), is(expectedTokens));
+        verify(boundRequestBuilder).execute();
+    }
+
+    @Test
+    public void whenOnlyTextShouldTargetAnalyzeAndNotAddAdditionalParamsAndPreserveCase() throws Exception {
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object("text", "Hello World").toString());
+    }
+
+    @Test
+    public void withSpecifiedAnalyzerShouldAddItAsParam() throws Exception {
+        helloWorldAnalyzeRequestBuilder.setAnalyzer("custom_one");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object(
+                "text", "Hello World",
+                "analyzer", "custom_one"
+        ).toString());
+    }
+
+    @Test
+    public void withSpecifiedTokenizerShouldAddItAsParam() throws Exception {
+        helloWorldAnalyzeRequestBuilder.setTokenizer("keyword");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object(
+                "text", "Hello World",
+                "tokenizer", "keyword"
+        ).toString());
+    }
+
+    @Test
+    public void withSpecifiedFieldShouldUseItAsParam() throws Exception {
+        helloWorldAnalyzeRequestBuilder.setField("myField");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object(
+                "text", "Hello World",
+                "field", "myField"
+        ).toString());
+    }
+
+    @Test
+    public void withSpecifiedFiltersShouldUseThemAndPerserveTheirOrder() throws Exception {
+        helloWorldAnalyzeRequestBuilder
+                .appendFilter("lowercase")
+                .appendFilter("unique");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object(
+                "text", new JsonPrimitive("Hello World"),
+                "filter", array(new JsonPrimitive("lowercase"), new JsonPrimitive("unique"))
+        ).toString());
+    }
+
+    @Test
+    public void withSpecifiedCharacterFiltersShouldUseThemAndPerserveTheirOrder() throws Exception {
+        helloWorldAnalyzeRequestBuilder
+                .appendCharacterFilter("html_strip")
+                .appendCharacterFilter("my_char_filter");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/_analyze");
+        verify(boundRequestBuilder).setBody(object(
+                "text", new JsonPrimitive("Hello World"),
+                "char_filter", array(new JsonPrimitive("html_strip"), new JsonPrimitive("my_char_filter"))
+        ).toString());
+    }
+
+    @Test
+    public void withEverythingShouldNotMissAnyParameter() throws Exception {
+        helloWorldAnalyzeRequestBuilder
+                .setIndexName("my-index")
+                .setTokenizer("keyword")
+                .setAnalyzer("custom_one")
+                .setField("myField")
+                .appendFilter("lowercase")
+                .appendFilter("unique")
+                .appendCharacterFilter("html_strip")
+                .appendCharacterFilter("my_char_filter");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        JsonObject expectedBody = new JsonObject();
+        expectedBody.add("text", new JsonPrimitive("Hello World"));
+        expectedBody.add("analyzer", new JsonPrimitive("custom_one"));
+        expectedBody.add("tokenizer", new JsonPrimitive("keyword"));
+        expectedBody.add("field", new JsonPrimitive("myField"));
+        expectedBody.add("filter", array(new JsonPrimitive("lowercase"), new JsonPrimitive("unique")));
+        expectedBody.add("char_filter", array(new JsonPrimitive("html_strip"), new JsonPrimitive("my_char_filter")));
+        verify(httpClient).prepareGet("/my-index/_analyze");
+        verify(boundRequestBuilder).setBody(expectedBody.toString());
+    }
+
+    @Test
+    public void withSpecifiedIndexNameShouldUseItInPath() throws Exception {
+        helloWorldAnalyzeRequestBuilder
+                .setIndexName("my-index");
+
+        // when
+        helloWorldAnalyzeRequestBuilder.execute();
+
+        // then
+        verify(httpClient).prepareGet("/my-index/_analyze");
+        verify(boundRequestBuilder).setBody(object("text", "Hello World").toString());
+    }
+
+    @Test(expectedExceptions = HttpServerErrorException.class)
+    public void shouldThrowWhenServerReturnsNon200StatusCode() throws Exception {
+        when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(404, "Not Found", object("status", new JsonPrimitive(404), "error", object()).toString())));
+
+        // when
+        try {
+            helloWorldAnalyzeRequestBuilder.execute();
+        }
+        // then
+        catch (HttpServerErrorException e) {
+            assertThat(e.getStatusCode(), is(404));
+            assertThat(e.getResponseBody(), is("{\"status\":404,\"error\":{}}"));
+            throw e;
+        }
+    }
+
+    private JsonObject createTokenJsonObject(String token, String type, Integer position, Integer startOffset, Integer endOffset) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.add("position", new JsonPrimitive(position));
+        jsonObject.add("type", new JsonPrimitive(type));
+        jsonObject.add("end_offset", new JsonPrimitive(endOffset));
+        jsonObject.add("start_offset", new JsonPrimitive(startOffset));
+        jsonObject.add("token", new JsonPrimitive(token));
+        return jsonObject;
+    }
+}


### PR DESCRIPTION
I needed the _analyze API, so I went ahead and implemented it. We use the API to extensively test if things are stored and searched properly.

Almost all cases from [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.3/indices-analyze.html) are implemented. I only skipped case with text as array:
`{
  "text" : ["this is a test", "the second text"]
}`

I tried to blend my code style as much as possible to surrounding code.