### PR TITLE
Make compatible with ElasticSearch 6.x - add Content-Type Header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 
 group = 'de.otto'
 archivesBaseName='flummi'
-version='5.0.32.0'
+version='6.0.0.0'
 
 if (project.hasProperty('isSnapshot')) {
     version += '-SNAPSHOT'
@@ -84,7 +84,7 @@ if (!project.hasProperty('isSnapshot')) {
 
 dependencies {
     compile "com.google.code.gson:gson:2.8.0"
-    compile "org.asynchttpclient:async-http-client:2.0.37"
+    compile "org.asynchttpclient:async-http-client:2.4.4"
     
     //compile "com.ning:async-http-client:1.9.40"
     compile "org.slf4j:slf4j-api:1.7.22"

--- a/src/main/java/de/otto/flummi/IndicesAdminClient.java
+++ b/src/main/java/de/otto/flummi/IndicesAdminClient.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import static de.otto.flummi.request.GsonHelper.object;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static java.util.stream.Collectors.toList;
 
 public class IndicesAdminClient {
@@ -52,7 +54,10 @@ public class IndicesAdminClient {
 
     public JsonObject getIndexSettings() {
         try {
-            Response response = httpClient.prepareGet("/_all/_settings").execute().get();
+
+            Response response = httpClient.prepareGet("/_all/_settings")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() != 200) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }
@@ -63,24 +68,28 @@ public class IndicesAdminClient {
             throw new RuntimeException(e);
         }
     }
-    
-    public JsonObject getIndexMapping(String indexName){
-      try {
-        Response response = httpClient.prepareGet("/" + indexName+"/_mapping").execute().get();
-        if (response.getStatusCode() != 200) {
-            throw RequestBuilderUtil.toHttpServerErrorException(response);
+
+    public JsonObject getIndexMapping(String indexName) {
+        try {
+            Response response = httpClient.prepareGet("/" + indexName + "/_mapping")
+                    .addHeader("Content-Type", "application/json")
+                    .execute().get();
+            if (response.getStatusCode() != 200) {
+                throw RequestBuilderUtil.toHttpServerErrorException(response);
+            }
+            String jsonString = null;
+            jsonString = response.getResponseBody();
+            return gson.fromJson(jsonString, JsonObject.class);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
-        String jsonString = null;
-        jsonString = response.getResponseBody();
-        return gson.fromJson(jsonString, JsonObject.class);
-	    } catch (InterruptedException | ExecutionException e) {
-	        throw new RuntimeException(e);
-	    }
     }
 
     public List<String> getAllIndexNames() {
         try {
-            Response response = httpClient.prepareGet("/_all").execute().get();
+            Response response = httpClient.prepareGet("/_all")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() != 200) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }
@@ -97,7 +106,9 @@ public class IndicesAdminClient {
 
     public Optional<String> getIndexNameForAlias(String aliasName) {
         try {
-            Response response = httpClient.prepareGet("/_aliases").execute().get();
+            Response response = httpClient.prepareGet("/_aliases")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() != 200) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }
@@ -125,6 +136,7 @@ public class IndicesAdminClient {
 
             Response response = httpClient
                     .preparePost("/_aliases")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .setBody(gson.toJson(jsonObject))
                     .execute().get();
             if (response.getStatusCode() >= 300) {
@@ -148,7 +160,9 @@ public class IndicesAdminClient {
 
     public boolean aliasExists(String aliasName) {
         try {
-            Response response = httpClient.prepareGet("/_aliases").execute().get();
+            Response response = httpClient.prepareGet("/_aliases")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() != 200) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/AnalyzeRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/AnalyzeRequestBuilder.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class AnalyzeRequestBuilder implements RequestBuilder<AnalyzeResponse> {
@@ -67,6 +69,7 @@ public class AnalyzeRequestBuilder implements RequestBuilder<AnalyzeResponse> {
             Response response = httpClient
                     .prepareGet(url)
                     .setCharset(Charset.forName("UTF-8"))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .setBody(gson.toJson(body))
                     .execute()
                     .get();

--- a/src/main/java/de/otto/flummi/request/BulkRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/BulkRequestBuilder.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class BulkRequestBuilder implements RequestBuilder<Void> {
@@ -53,7 +55,8 @@ public class BulkRequestBuilder implements RequestBuilder<Void> {
 
 	        final BoundRequestBuilder boundRequestBuilder = httpClient
 	                .preparePost("/_bulk")
-	                .setBody(postBody.toString())
+.addHeader(CONTENT_TYPE,APPL_JSON)
+                    .setBody(postBody.toString())
 	                .setCharset(Charset.forName("UTF-8"));
 
             Response response = boundRequestBuilder.execute().get();

--- a/src/main/java/de/otto/flummi/request/ClusterHealthRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/ClusterHealthRequestBuilder.java
@@ -13,6 +13,8 @@ import org.slf4j.Logger;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class ClusterHealthRequestBuilder implements RequestBuilder<ClusterHealthResponse> {
@@ -49,7 +51,8 @@ public class ClusterHealthRequestBuilder implements RequestBuilder<ClusterHealth
             if (timeout != null) {
                 requestBuilder.addQueryParam("timeout", timeout + "ms");
             }
-            Response response = requestBuilder.execute().get();
+            Response response = requestBuilder.addHeader(CONTENT_TYPE,APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/CountRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/CountRequestBuilder.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class CountRequestBuilder implements RequestBuilder<Long> {
@@ -36,7 +38,9 @@ public class CountRequestBuilder implements RequestBuilder<Long> {
     public Long execute() {
         try {
             String url = RequestBuilderUtil.buildUrl(indices, types, "_count");
-            Response response = httpClient.prepareGet(url).execute().get();
+            Response response = httpClient.prepareGet(url)
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/CreateIndexRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/CreateIndexRequestBuilder.java
@@ -11,6 +11,8 @@ import org.slf4j.Logger;
 import java.nio.charset.Charset;
 import java.util.concurrent.ExecutionException;
 
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class CreateIndexRequestBuilder implements RequestBuilder<Void> {
@@ -48,7 +50,9 @@ public class CreateIndexRequestBuilder implements RequestBuilder<Void> {
             jsonObject.add("mappings", mappings);
         }
         try {
-            Response response = httpClient.preparePut("/" + indexName).setBody(jsonObject.toString()).setCharset(Charset.forName("UTF-8")).execute().get();
+            Response response = httpClient.preparePut("/" + indexName).setBody(jsonObject.toString()).setCharset(Charset.forName("UTF-8"))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/DeleteIndexRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/DeleteIndexRequestBuilder.java
@@ -7,6 +7,8 @@ import org.asynchttpclient.Response;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static java.util.stream.Collectors.toList;
 
 public class DeleteIndexRequestBuilder implements RequestBuilder<Void> {
@@ -24,7 +26,9 @@ public class DeleteIndexRequestBuilder implements RequestBuilder<Void> {
         }
         try {
             String url = RequestBuilderUtil.buildUrl(indexNames, null, null);
-            Response response = httpClient.prepareDelete(url).execute().get();
+            Response response = httpClient.prepareDelete(url)
+.addHeader(CONTENT_TYPE,APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300 && response.getStatusCode() != 404) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/DeleteRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/DeleteRequestBuilder.java
@@ -10,6 +10,8 @@ import java.net.URLEncoder;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.buildUrl;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class DeleteRequestBuilder implements RequestBuilder<Void> {
@@ -41,16 +43,17 @@ public class DeleteRequestBuilder implements RequestBuilder<Void> {
 
     public Void execute() {
         try {
-            if (indexName==null || indexName.isEmpty()) {
+            if (indexName == null || indexName.isEmpty()) {
                 throw new RuntimeException("missing property 'indexName'");
             }
-            if (documentType==null || documentType.isEmpty()) {
+            if (documentType == null || documentType.isEmpty()) {
                 throw new RuntimeException("missing property 'type'");
             }
-            if (id==null || id.isEmpty()) {
+            if (id == null || id.isEmpty()) {
                 throw new RuntimeException("missing property 'id'");
             }
             Response response = httpClient.prepareDelete(buildUrl(indexName, documentType, URLEncoder.encode(id, "UTF-8")))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw RequestBuilderUtil.toHttpServerErrorException(response);

--- a/src/main/java/de/otto/flummi/request/ForceMergeRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/ForceMergeRequestBuilder.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class ForceMergeRequestBuilder {
@@ -22,7 +24,9 @@ public class ForceMergeRequestBuilder {
 
     public void execute() {
         try {
-            Response response = httpClient.preparePost("/" + indexName + "/_forcemerge").execute().get();
+            Response response = httpClient.preparePost("/" + indexName + "/_forcemerge")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/GetRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/GetRequestBuilder.java
@@ -14,6 +14,8 @@ import java.net.URLEncoder;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class GetRequestBuilder implements RequestBuilder<GetResponse> {
@@ -37,7 +39,9 @@ public class GetRequestBuilder implements RequestBuilder<GetResponse> {
     public GetResponse execute() {
         try {
             String url = RequestBuilderUtil.buildUrl(indexName, documentType, URLEncoder.encode(id, "UTF-8"));
-            Response response = httpClient.prepareGet(url).execute().get();
+            Response response = httpClient.prepareGet(url)
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300 && 404 != response.getStatusCode()) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/IndexRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/IndexRequestBuilder.java
@@ -16,6 +16,8 @@ import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.buildUrl;
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class IndexRequestBuilder implements RequestBuilder<Void> {
@@ -95,7 +97,9 @@ public class IndexRequestBuilder implements RequestBuilder<Void> {
             }
 
             String body = createBody();
-            Response response = reqBuilder.setBody(body).setCharset(Charset.forName("UTF-8")).execute().get();
+            Response response = reqBuilder.setBody(body).setCharset(Charset.forName("UTF-8"))
+.addHeader(CONTENT_TYPE,APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/IndicesExistsRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/IndicesExistsRequestBuilder.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 
 import java.util.concurrent.ExecutionException;
 
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class IndicesExistsRequestBuilder implements RequestBuilder<Boolean> {
@@ -22,7 +24,9 @@ public class IndicesExistsRequestBuilder implements RequestBuilder<Boolean> {
 
     public Boolean execute() {
         try {
-            Response response = httpClient.prepareHead("/" + indexName).execute().get();
+            Response response = httpClient.prepareHead("/" + indexName)
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             int statusCode = response.getStatusCode();
             if (statusCode >= 300 && response.getStatusCode() != 404) {
                 throw new HttpServerErrorException(response.getStatusCode(), response.getStatusText(), response.getResponseBody());

--- a/src/main/java/de/otto/flummi/request/MultiGetRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/MultiGetRequestBuilder.java
@@ -17,6 +17,8 @@ import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
 import static de.otto.flummi.request.GsonHelper.array;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -70,6 +72,7 @@ public class MultiGetRequestBuilder implements RequestBuilder<MultiGetResponse> 
             }
             long start = System.currentTimeMillis();
             Response response = boundRequestBuilder.setBody(gson.toJson(body))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .execute()
                     .get();
 

--- a/src/main/java/de/otto/flummi/request/RefreshRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/RefreshRequestBuilder.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class RefreshRequestBuilder {
@@ -22,7 +24,9 @@ public class RefreshRequestBuilder {
 
     public void execute() {
         try {
-            Response response = httpClient.preparePost("/" + indexName + "/_refresh").execute().get();
+            Response response = httpClient.preparePost("/" + indexName + "/_refresh")
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
+                    .execute().get();
             if (response.getStatusCode() >= 300) {
                 throw toHttpServerErrorException(response);
             }

--- a/src/main/java/de/otto/flummi/request/RequestConstants.java
+++ b/src/main/java/de/otto/flummi/request/RequestConstants.java
@@ -1,0 +1,9 @@
+package de.otto.flummi.request;
+
+public final class RequestConstants {
+    public static final String  CONTENT_TYPE = "Content-Type";
+    public static final String APPL_JSON = "application/json";
+
+    private RequestConstants(){};
+
+}

--- a/src/main/java/de/otto/flummi/request/SearchRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/SearchRequestBuilder.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collector;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static de.otto.flummi.response.SearchResponse.emptyResponse;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -159,6 +161,7 @@ public class SearchRequestBuilder implements RequestBuilder<SearchResponse> {
             }
 
             Response response = boundRequestBuilder.setBody(gson.toJson(body))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .execute()
                     .get();
 

--- a/src/main/java/de/otto/flummi/request/SearchScrollRequestBuilder.java
+++ b/src/main/java/de/otto/flummi/request/SearchScrollRequestBuilder.java
@@ -10,6 +10,8 @@ import java.util.concurrent.ExecutionException;
 
 import static de.otto.flummi.RequestBuilderUtil.toHttpServerErrorException;
 import static de.otto.flummi.request.GsonHelper.object;
+import static de.otto.flummi.request.RequestConstants.APPL_JSON;
+import static de.otto.flummi.request.RequestConstants.CONTENT_TYPE;
 import static de.otto.flummi.request.SearchRequestBuilder.parseResponse;
 import static de.otto.flummi.response.SearchResponse.emptyResponse;
 
@@ -43,6 +45,7 @@ public class SearchScrollRequestBuilder implements RequestBuilder<SearchResponse
         try {
             Response response = httpClient.preparePost("/_search/scroll")
                     .setBody(gson.toJson(requestBody))
+                    .addHeader(CONTENT_TYPE, APPL_JSON)
                     .execute()
                     .get();
 

--- a/src/test/java/de/otto/flummi/AdminClientTest.java
+++ b/src/test/java/de/otto/flummi/AdminClientTest.java
@@ -41,6 +41,7 @@ public class AdminClientTest {
         when(response.getResponseBody()).thenReturn("{\"status\":\"GREEN\", \"cluster_name\":\"someClusterName\", \"timed_out\":\"someTimedOut\"}");
         when(listenableFuture.get()).thenReturn(response);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(httpClient.prepareGet(anyString())).thenReturn(boundRequestBuilder);
         final ClusterAdminClient cluster = adminClient.cluster();
         final ClusterHealthRequestBuilder clusterHealthRequestBuilder = cluster.prepareHealth("someIndexName");
@@ -62,6 +63,7 @@ public class AdminClientTest {
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         final ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(200);

--- a/src/test/java/de/otto/flummi/CountRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/CountRequestBuilderTest.java
@@ -29,6 +29,7 @@ public class CountRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareGet("/product-index/_count")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"count\" : 42}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         long result = testee.execute();
@@ -43,6 +44,7 @@ public class CountRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareGet("/product-index/bla,blupp/_count")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"count\" : 42}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         long result = testee.setTypes("bla", "blupp").execute();
@@ -57,6 +59,8 @@ public class CountRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareGet("/product-index/bla/_count")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"count\" : 23}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
+
         // when
         long result = testee.setTypes("bla").execute();
 
@@ -70,6 +74,8 @@ public class CountRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareGet("/product-index/bla/_count")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"error\" : \"miserable failure\" }")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
+
         // when
         try {
             testee.setTypes("bla").execute();

--- a/src/test/java/de/otto/flummi/FlummiTest.java
+++ b/src/test/java/de/otto/flummi/FlummiTest.java
@@ -44,6 +44,7 @@ public class FlummiTest {
     public void shouldGetIndexNameForAlias() throws ExecutionException, InterruptedException, IOException {
         //Given
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"someIndexName\":{\"aliases\": {\"someAliasName\": {}}}}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         //When
         final Optional<String> indexNameForAlias = client.getIndexNameForAlias("someAliasName");
@@ -57,6 +58,7 @@ public class FlummiTest {
     public void shouldNotGetIndexNameForAliasIfAliasNotExists() throws ExecutionException, InterruptedException, IOException {
         //Given
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"someIndexName\":{\"aliases\": {\"someOtherAliasName\": {}}}}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         //When
         final Optional<String> indexNameForAlias = client.getIndexNameForAlias("someAliasName");
@@ -69,6 +71,7 @@ public class FlummiTest {
     public void shouldNotGetIndexNameForAliasForErrorResponseCode() throws ExecutionException, InterruptedException, IOException {
         //Given
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"someIndexName\":{\"aliases\": {\"someAliasName\": {}}}}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         //When
         client.getIndexNameForAlias("someAliasName");
@@ -77,6 +80,7 @@ public class FlummiTest {
     @Test
     public void shouldPrepareSearch() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"took\":123, \"hits\": {\"total\": 3, \"max_score\":1, \"hits\": []}}")));
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         //When
@@ -97,6 +101,7 @@ public class FlummiTest {
         final ListenableFuture listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(200);
@@ -119,6 +124,7 @@ public class FlummiTest {
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(200);
@@ -139,6 +145,7 @@ public class FlummiTest {
         final BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         when(asyncHttpClient.prepareGet(anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);
@@ -160,6 +167,7 @@ public class FlummiTest {
         when(asyncHttpClient.prepareDelete(anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(200);
@@ -182,6 +190,7 @@ public class FlummiTest {
         final ListenableFuture listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
         when(response.getStatusCode()).thenReturn(200);
@@ -203,6 +212,7 @@ public class FlummiTest {
         when(asyncHttpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
@@ -228,6 +238,7 @@ public class FlummiTest {
         when(response.getResponseBody()).thenReturn("{\"status\":\"GREEN\", \"cluster_name\":\"someClusterName\", \"timed_out\":\"someTimedOut\"}");
         when(listenableFuture.get()).thenReturn(response);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(asyncHttpClient.prepareGet(anyString())).thenReturn(boundRequestBuilder);
         final ClusterAdminClient cluster = client.admin().cluster();
         final ClusterHealthRequestBuilder clusterHealthRequestBuilder = cluster.prepareHealth("someIndexName");
@@ -248,6 +259,7 @@ public class FlummiTest {
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         final ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
         when(listenableFuture.get()).thenReturn(response);

--- a/src/test/java/de/otto/flummi/IndicesAdminClientTest.java
+++ b/src/test/java/de/otto/flummi/IndicesAdminClientTest.java
@@ -46,6 +46,7 @@ public class IndicesAdminClientTest {
         when(httpClient.preparePut(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
@@ -66,6 +67,7 @@ public class IndicesAdminClientTest {
         //Given
         when(httpClient.prepareHead(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
@@ -85,6 +87,7 @@ public class IndicesAdminClientTest {
         //Given
         when(httpClient.prepareDelete(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         final ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         final Response response = mock(Response.class);
@@ -102,6 +105,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldReturnAliasExists() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"someIndexName\":{\"aliases\": {\"someAlias\": {}}}}")));
 
         //When
@@ -115,6 +119,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldReturnAliasNotExists() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"someIndexName\":{\"aliases\": {\"someOtherAlias\": {}}}}")));
 
         //When
@@ -128,6 +133,7 @@ public class IndicesAdminClientTest {
     @Test(expectedExceptions = HttpServerErrorException.class)
     public void shouldReturnAliasNotExistsFor500() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"someIndexName\":{\"aliases\": {\"someAlias\": {}}}}")));
 
         //When
@@ -137,6 +143,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldGetAllIndexNames() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"someIndexName\":{}, \"someIndexName2\":{}, \"someIndexName3\":{}}")));
 
         //When
@@ -153,6 +160,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldNotGetAllIndexNamesForEmptyResponse() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{}")));
 
         //When
@@ -166,6 +174,7 @@ public class IndicesAdminClientTest {
     @Test(expectedExceptions = HttpServerErrorException.class)
     public void shouldNotGetAllIndexNamesForErrorResponseCode() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "OK", "{}")));
 
         //When
@@ -175,6 +184,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldGetIndexSettings() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"jobs-test\": {\n" +
                 "    \"settings\": {\n" +
                 "      \"index\": {\n" +
@@ -205,6 +215,7 @@ public class IndicesAdminClientTest {
     @Test(expectedExceptions = HttpServerErrorException.class)
     public void shouldGetIndexSettingsForErrorResponseCode() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"jobs-test\": {\n" +
                 "    \"settings\": {\n" +
                 "      \"index\": {\n" +
@@ -226,6 +237,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldGetIndexSettingsForEmptyResponse() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{}")));
 
         //When
@@ -238,6 +250,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldGetIndexMapping() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", ""+
             "{\"mapping-test\" : {\n" +
             "   \"mappings\" : {\n" +
@@ -267,6 +280,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldRefreshIndex() throws ExecutionException, InterruptedException {
         when(httpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{}")));
 
         //When
@@ -279,6 +293,7 @@ public class IndicesAdminClientTest {
     @Test
     public void shouldForceMergeOfIndex() throws ExecutionException, InterruptedException {
         when(httpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{}")));
 
         //When
@@ -291,6 +306,7 @@ public class IndicesAdminClientTest {
     @Test(expectedExceptions = HttpServerErrorException.class)
     public void shouldFailToRefreshIndexForErrorResponse() throws ExecutionException, InterruptedException {
         when(httpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"errors\":\"true\"}")));
 
         //When
@@ -302,6 +318,7 @@ public class IndicesAdminClientTest {
         //Given
         when(httpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"acknowledged\":true}")));
 
         //When
@@ -315,6 +332,7 @@ public class IndicesAdminClientTest {
     @Test(expectedExceptions = RuntimeException.class)
     public void shouldNotPointProductAliasToCurrentIndexForAcknowledgedFalse() throws ExecutionException, InterruptedException, IOException {
         //Given
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"acknowledged\":false}")));
 
         //When
@@ -326,6 +344,7 @@ public class IndicesAdminClientTest {
         //Given
         when(httpClient.preparePost(anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(anyString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(500, "Internal Server Error", "{\"errors\":\"true\"}")));
 
         //When

--- a/src/test/java/de/otto/flummi/MockResponse.java
+++ b/src/test/java/de/otto/flummi/MockResponse.java
@@ -1,8 +1,8 @@
 package de.otto.flummi;
 
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.cookie.Cookie;
 import org.asynchttpclient.Response;
-import org.asynchttpclient.cookie.Cookie;
 import org.asynchttpclient.uri.Uri;
 
 import java.io.InputStream;
@@ -74,14 +74,15 @@ public class MockResponse implements Response {
     }
 
     @Override
-    public String getHeader(String name) {
-        return null;
+    public String getHeader(CharSequence name) {
+        return "";
     }
 
     @Override
-    public List<String> getHeaders(String name) {
-        return emptyList();
+    public List<String> getHeaders(CharSequence name) {
+        return null;
     }
+
 
     @Override
     public boolean isRedirected() {

--- a/src/test/java/de/otto/flummi/SearchRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/SearchRequestBuilderTest.java
@@ -79,6 +79,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -96,6 +97,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -113,6 +115,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", SEARCH_RESPONSE_WITH_ONE_HIT)));
 
         // when
@@ -140,6 +143,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", SEARCH_RESPONSE_WITH_AGGREGATION)));
 
         // when
@@ -169,6 +173,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -186,6 +191,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -204,6 +210,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -221,6 +228,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -238,6 +246,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -255,6 +264,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -275,6 +285,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", SEARCH_RESPONSE_WITH_SCROLL_ID)));
 
         // when
@@ -296,6 +307,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", EMPTY_SEARCH_RESPONSE)));
 
         // when
@@ -331,6 +343,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", SEARCH_RESPONSE_WITH_SCROLL_ID)));
 
         // when
@@ -358,6 +371,7 @@ public class SearchRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_search")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         TimeoutException timeoutException = new TimeoutException();
         when(boundRequestBuilderMock.execute()).thenReturn(new ListenableFuture.CompletedFailure<>(timeoutException));
 

--- a/src/test/java/de/otto/flummi/request/AnalyzeRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/AnalyzeRequestBuilderTest.java
@@ -59,6 +59,7 @@ public class AnalyzeRequestBuilderTest {
         when(boundRequestBuilder.execute()).thenReturn(
                 new CompletedFuture<>(new MockResponse(200, "ok", helloWorldResponse.toString()))
         );
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         AnalyzeResponse analyzerResponse = helloWorldAnalyzeRequestBuilder.execute();
@@ -74,6 +75,7 @@ public class AnalyzeRequestBuilderTest {
 
     @Test
     public void whenOnlyTextShouldTargetAnalyzeAndNotAddAdditionalParamsAndPreserveCase() throws Exception {
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         helloWorldAnalyzeRequestBuilder.execute();
 
         verify(httpClient).prepareGet("/_analyze");
@@ -83,6 +85,7 @@ public class AnalyzeRequestBuilderTest {
     @Test
     public void withSpecifiedAnalyzerShouldAddItAsParam() throws Exception {
         helloWorldAnalyzeRequestBuilder.setAnalyzer("custom_one");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -98,6 +101,7 @@ public class AnalyzeRequestBuilderTest {
     @Test
     public void withSpecifiedTokenizerShouldAddItAsParam() throws Exception {
         helloWorldAnalyzeRequestBuilder.setTokenizer("keyword");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -113,6 +117,7 @@ public class AnalyzeRequestBuilderTest {
     @Test
     public void withSpecifiedFieldShouldUseItAsParam() throws Exception {
         helloWorldAnalyzeRequestBuilder.setField("myField");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -130,6 +135,7 @@ public class AnalyzeRequestBuilderTest {
         helloWorldAnalyzeRequestBuilder
                 .appendFilter("lowercase")
                 .appendFilter("unique");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -147,6 +153,7 @@ public class AnalyzeRequestBuilderTest {
         helloWorldAnalyzeRequestBuilder
                 .appendCharacterFilter("html_strip")
                 .appendCharacterFilter("my_char_filter");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -172,6 +179,7 @@ public class AnalyzeRequestBuilderTest {
                 .appendCharacterFilter("my_char_filter");
 
         // when
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         helloWorldAnalyzeRequestBuilder.execute();
 
         // then
@@ -190,6 +198,7 @@ public class AnalyzeRequestBuilderTest {
     public void withSpecifiedIndexNameShouldUseItInPath() throws Exception {
         helloWorldAnalyzeRequestBuilder
                 .setIndexName("my-index");
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         helloWorldAnalyzeRequestBuilder.execute();
@@ -202,6 +211,7 @@ public class AnalyzeRequestBuilderTest {
     @Test(expectedExceptions = HttpServerErrorException.class)
     public void shouldThrowWhenServerReturnsNon200StatusCode() throws Exception {
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(404, "Not Found", object("status", new JsonPrimitive(404), "error", object()).toString())));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
 
         // when
         try {

--- a/src/test/java/de/otto/flummi/request/BulkRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/BulkRequestBuilderTest.java
@@ -42,6 +42,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":false}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -63,6 +64,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok", "{\"errors\":false}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -87,6 +89,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"index\":{\"status\":400,\"error\":\"someError\"}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -108,6 +111,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"update\":{\"status\":404,\"error\":\"someError\"}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -125,6 +129,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"index\":{\"status\":503,\"error\":\"someError\"}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -146,6 +151,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"create\":{\"status\":200}},{\"delete\":{\"status\":503,\"error\":\"someError\"}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -167,6 +173,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"create\":{\"status\":200}},{\"update\":{\"status\":404,\"error\":\"someError\"}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 
@@ -184,6 +191,7 @@ public class BulkRequestBuilderTest {
         when(boundRequestBuilderMock.setBody("{\"index\":{\"_index\":\"someIndex\",\"_type\":\"Flutschfinger\"}}\n{\"Eis\":\"am Stiel\"}\n")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"errors\":true,\"items\":[{\"update\":{\"_index\":\"mytestindex\",\"_type\":\"product\",\"_id\":\"340891232\",\"status\":409}}]}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         testee.add(new IndexActionBuilder("someIndex").setOpType(IndexOpType.INDEX).setType("Flutschfinger").setSource(object("Eis", "am Stiel")));
 

--- a/src/test/java/de/otto/flummi/request/ClusterHealthRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/ClusterHealthRequestBuilderTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ClusterHealthRequestBuilderTest {
 
@@ -29,14 +30,15 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"status\": \"green\",\n" +
                         "  \"timed_out\": false" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         ClusterHealthResponse healthResponse = testee.execute();
@@ -52,14 +54,15 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"status\": \"green\",\n" +
                         "  \"timed_out\": false" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         ClusterHealthResponse healthResponse = testee.setTimeout(1000).execute();
@@ -76,14 +79,15 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addQueryParam(anyString(), anyString())).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"status\": \"green\",\n" +
                         "  \"timed_out\": false" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         ClusterHealthResponse healthResponse = testee.setWaitForYellowStatus().execute();
@@ -100,12 +104,13 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"timed_out\": false" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         try {
@@ -122,12 +127,13 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"status\": \"red\"" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         try {
@@ -144,12 +150,13 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"timed_out\": false,\n" +
                         "  \"status\": \"red\"" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         try {
@@ -166,13 +173,14 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"timed_out\": true,\n" +
                         "  \"status\": \"red\"" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         try {
@@ -189,13 +197,14 @@ public class ClusterHealthRequestBuilderTest {
         // given
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
 
-        Mockito.when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
-        Mockito.when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok",
+        when(asyncHttpClient.prepareGet("/_cluster/health/someIndex,someOtherIndex")).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok",
                 "{\n" +
                         "  \"cluster_name\": \"myCluster\",\n" +
                         "  \"timed_out\": false,\n" +
                         "  \"status\": \"red\"" +
                         "}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
 
         // when
         try {

--- a/src/test/java/de/otto/flummi/request/CreateIndexRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/CreateIndexRequestBuilderTest.java
@@ -15,6 +15,7 @@ import java.nio.charset.Charset;
 import static de.otto.flummi.request.GsonHelper.object;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,7 @@ public class CreateIndexRequestBuilderTest {
         when(boundRequestBuilder.setBody(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"acknowledged\": true}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         testee
                 .setMappings(object("someType", object("someField", object("someSetting", "someValue"))));
         // when
@@ -61,6 +63,7 @@ public class CreateIndexRequestBuilderTest {
         when(boundRequestBuilder.setBody(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "{\"acknowledged\": true}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         testee
                 .setSettings(object("someSetting", "someValue"));
         // when
@@ -79,6 +82,7 @@ public class CreateIndexRequestBuilderTest {
         when(boundRequestBuilder.setBody(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "Bad Request", "someBadBody")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         testee
                 .setSettings(object("someSetting", "someValue"));
         // when
@@ -101,6 +105,7 @@ public class CreateIndexRequestBuilderTest {
         when(boundRequestBuilder.setBody(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"acknowledged\": false}")));
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         testee
                 .setSettings(object("someSetting", "someValue"));
         // when

--- a/src/test/java/de/otto/flummi/request/DeleteIndexRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/DeleteIndexRequestBuilderTest.java
@@ -34,6 +34,7 @@ public class DeleteIndexRequestBuilderTest {
 
         when(httpClient.prepareDelete("/someIndexName")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         testee.execute();
         verify(httpClient).prepareDelete("/someIndexName");
     }
@@ -45,6 +46,7 @@ public class DeleteIndexRequestBuilderTest {
 
         when(httpClient.prepareDelete("/someIndexName,someOtherIndex")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         testee.execute();
         verify(httpClient).prepareDelete("/someIndexName,someOtherIndex");
     }
@@ -55,6 +57,7 @@ public class DeleteIndexRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareDelete("/someIndexName")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok", "")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         try {
             testee.execute();
         } catch (HttpServerErrorException e) {
@@ -69,6 +72,7 @@ public class DeleteIndexRequestBuilderTest {
         BoundRequestBuilder boundRequestBuilderMock = mock(BoundRequestBuilder.class);
         when(httpClient.prepareDelete("/someIndexName")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", "{\"acknowledged\":\"false\"}")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         try {
             testee.execute();
         } catch (InvalidElasticsearchResponseException e) {

--- a/src/test/java/de/otto/flummi/request/DeleteRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/DeleteRequestBuilderTest.java
@@ -29,6 +29,7 @@ public class DeleteRequestBuilderTest {
 
         when(httpClient.prepareDelete("/someIndexName/someType/someId")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         testee.setDocumentType("someType")
                 .setIndexName("someIndexName")
                 .setId("someId")
@@ -75,6 +76,7 @@ public class DeleteRequestBuilderTest {
 
         when(httpClient.prepareDelete("/someIndexName/someType/someId")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok", "errorResponse")));
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         try {
             testee.setDocumentType("someType")
                     .setId("someId")

--- a/src/test/java/de/otto/flummi/request/ForceMergeRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/ForceMergeRequestBuilderTest.java
@@ -27,6 +27,7 @@ public class ForceMergeRequestBuilderTest {
         // given
         ForceMergeRequestBuilder forceMergeRequestBuilder = new ForceMergeRequestBuilder(httpClient, "someIndexName");
         when(httpClient.preparePost(any(String.class))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "OK", "")));
 
         // when

--- a/src/test/java/de/otto/flummi/request/GetRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/GetRequestBuilderTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -35,6 +36,7 @@ public class GetRequestBuilderTest {
     public void shouldExecuteFlushIndex() throws Exception {
         // given
         when(httpClient.prepareGet("/someIndex/someType/someId")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok",
                 "{\n" +
                         "  \"_index\": \"product_1461747600019\",\n" +
@@ -67,6 +69,7 @@ public class GetRequestBuilderTest {
     public void shouldThrowExceptionIfHttpStatusIsNotEqual400() throws Exception {
         // given
         when(httpClient.prepareGet("/someIndex/someType/someId")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(400, "not ok",
                 "{}")));
         // when

--- a/src/test/java/de/otto/flummi/request/IndexRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/IndexRequestBuilderTest.java
@@ -36,6 +36,7 @@ public class IndexRequestBuilderTest {
     public void shouldFireIndexRequestWithId() throws Exception {
         when(httpClient.preparePut(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "OK", "{\"allet tutti\":\"wa\"}")));
         testee
                 .setSource(object("some", object("friggin", "source")))
@@ -56,6 +57,7 @@ public class IndexRequestBuilderTest {
     public void shouldFireIndexRequestWithoutId() throws Exception {
         when(httpClient.preparePost(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "OK", "{\"allet tutti\":\"wa\"}")));
         testee
                 .setSource(object("some", object("friggin", "source")))
@@ -74,6 +76,7 @@ public class IndexRequestBuilderTest {
     public void shouldThrowWhenServerReturnsBadStatusCode() throws Exception {
         when(httpClient.preparePost(any(String.class))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(400, "Bad Request", "{\"query\":\"war kaputt\"}")));
         testee
                 .setSource(object("some", object("friggin", "source")))

--- a/src/test/java/de/otto/flummi/request/IndicesExistsRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/IndicesExistsRequestBuilderTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -37,6 +38,7 @@ public class IndicesExistsRequestBuilderTest {
     public void shouldSendIndexExistsRequestForNotExistingIndex() throws Exception {
         // given
         when(httpClient.prepareHead("/" + INDEX_NAME)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(404, "ok", "someBody")));
 
         // when
@@ -52,6 +54,7 @@ public class IndicesExistsRequestBuilderTest {
     public void shouldSendIndexExistsRequestForExistingIndex() throws Exception {
         // given
         when(httpClient.prepareHead("/" + INDEX_NAME)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "ok", "someBody")));
 
         // when
@@ -67,6 +70,7 @@ public class IndicesExistsRequestBuilderTest {
     public void shouldThrowWhenServerReturnsBadStatusCode() throws Exception {
         // given
         when(httpClient.prepareHead("/" + INDEX_NAME)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(503, "Varnish ist ein guter Proxy", "someBodyDanceWithMe")));
 
         // when

--- a/src/test/java/de/otto/flummi/request/MultiGetRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/MultiGetRequestBuilderTest.java
@@ -96,6 +96,7 @@ public class MultiGetRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_mget")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", ONE_DOC_FOUND_RESPONSE)));
 
         // when
@@ -115,6 +116,7 @@ public class MultiGetRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_mget")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", TWO_DOC_FOUND_RESPONSE)));
 
         // when
@@ -135,6 +137,7 @@ public class MultiGetRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_mget")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", ONE_DOC_FOUND_RESPONSE)));
 
         // when
@@ -151,6 +154,7 @@ public class MultiGetRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_mget")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(404, "not found", "")));
 
         // when
@@ -167,6 +171,7 @@ public class MultiGetRequestBuilderTest {
         when(httpClient.preparePost("/some-index/_mget")).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setBody(any(String.class))).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.setCharset(Charset.forName("UTF-8"))).thenReturn(boundRequestBuilderMock);
+        when(boundRequestBuilderMock.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilderMock);
         when(boundRequestBuilderMock.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "ok", NOT_FOUND_RESPONSE)));
 
         // when

--- a/src/test/java/de/otto/flummi/request/RefreshRequestBuilderTest.java
+++ b/src/test/java/de/otto/flummi/request/RefreshRequestBuilderTest.java
@@ -27,6 +27,7 @@ public class RefreshRequestBuilderTest {
         // given
         RefreshRequestBuilder refreshRequestBuilder = new RefreshRequestBuilder(httpClient, "someIndexName");
         when(httpClient.preparePost(any(String.class))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.addHeader(anyString(),anyString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(new CompletedFuture<>(new MockResponse(200, "OK", "")));
 
         // when

--- a/src/test/java/de/otto/flummi/response/ScrollingSearchHitsTest.java
+++ b/src/test/java/de/otto/flummi/response/ScrollingSearchHitsTest.java
@@ -68,6 +68,7 @@ public class ScrollingSearchHitsTest {
 
     @Test
     public void shouldFetchNextPage() throws Exception {
+        when(requestBuilder.addHeader(anyString(),anyString())).thenReturn(requestBuilder);
         when(requestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", NEXT_PAGE)));
         ScrollingSearchHits testee = new ScrollingSearchHits(100, 1F, "someScrollId", "1m", someSearchHits("P0", "P1"), httpClient);
         when(httpClient.preparePost(anyString())).thenReturn(requestBuilder);
@@ -85,6 +86,7 @@ public class ScrollingSearchHitsTest {
 
     @Test
     public void shouldSpliterate() throws Exception {
+        when(requestBuilder.addHeader(anyString(),anyString())).thenReturn(requestBuilder);
         when(requestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", NEXT_PAGE)));
         ScrollingSearchHits testee = new ScrollingSearchHits(100, 1F, "someScrollId", "1m", someSearchHits("P0", "P1"), httpClient);
         when(httpClient.preparePost(anyString())).thenReturn(requestBuilder);
@@ -99,6 +101,7 @@ public class ScrollingSearchHitsTest {
 
     @Test
     public void shouldFetchEmptyNextPage() throws Exception {
+        when(requestBuilder.addHeader(anyString(),anyString())).thenReturn(requestBuilder);
         when(requestBuilder.execute()).thenReturn(new CompletedFuture(new MockResponse(200, "OK", EMPTY_PAGE)));
         ScrollingSearchHits testee = new ScrollingSearchHits(100, 1F, "someScrollId", "1m", someSearchHits("P0", "P1"), httpClient);
         when(httpClient.preparePost(anyString())).thenReturn(requestBuilder);


### PR DESCRIPTION
- add Content-Type header to requests as mandatory with Elastic 6.x
- bump version to 6.0.0.0
- update async-http-client to 2.4.4
- update tests to mock addHeader calls as required by fluent api